### PR TITLE
Added additional readings for priority - Low, Normal, High, Urgent -

### DIFF
--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/CustomEnumParser.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/CustomEnumParser.cs
@@ -172,6 +172,12 @@ namespace ESRI.ArcLogistics
                 case OrderPriority.Normal:
                     supportedValues = Properties.Resources.OrderPriorityNormalSupportedValues;
                     break;
+				case OrderPriority.Low:
+                    supportedValues = Properties.Resources.OrderPriorityLowSupportedValues;
+                    break;
+                case OrderPriority.Urgent:
+                    supportedValues = Properties.Resources.OrderPriorityUrgentSupportedValues;
+                    break;   
                 default:
                     Debug.Assert(false); // NOTE: not supported
                     break;

--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/Enums.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/Enums.cs
@@ -111,13 +111,28 @@ namespace ESRI.ArcLogistics
     public enum OrderPriority
     {
         /// <summary>
-        /// High priorited servicing order.
+        /// Low priorited servicing order. 
+        /// Numeric value = 0
         /// </summary>
-        High,
+        Low = 0,
+
         /// <summary>
         /// Normal priorited servicing order.
+        /// Numeric value = 1
         /// </summary>
-        Normal
+        Normal = 1,
+
+        /// <summary>
+        /// High priorited servicing order.
+        /// Numeric value = 1000
+        /// </summary>
+        High = 1000,
+
+        /// <summary>
+        /// Urgent priorited servicing order.
+        /// Numeric value = 1000000
+        /// </summary>
+        Urgent = 1000000
     }
 
     public enum StopType

--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/Properties/Resources.Designer.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/Properties/Resources.Designer.cs
@@ -3865,6 +3865,15 @@ using System;
                 return ResourceManager.GetString("OrderPriorityHighSupportedValues", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Low.
+        /// </summary>
+        internal static string OrderPriorityLowSupportedValues {
+            get {
+                return ResourceManager.GetString("OrderPriorityLowSupportedValues", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Normal.
@@ -3872,6 +3881,15 @@ using System;
         internal static string OrderPriorityNormalSupportedValues {
             get {
                 return ResourceManager.GetString("OrderPriorityNormalSupportedValues", resourceCulture);
+            }
+        }
+        
+		/// <summary>
+        ///   Looks up a localized string similar to Urgent.
+        /// </summary>
+        internal static string OrderPriorityUrgentSupportedValues {
+            get {
+                return ResourceManager.GetString("OrderPriorityUrgentSupportedValues", resourceCulture);
             }
         }
         

--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/Properties/Resources.resx
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/Properties/Resources.resx
@@ -1737,6 +1737,14 @@
     <value>Normal</value>
     <comment>Supported OrderPriority.Normal values (separate by ','). Used in import.</comment>
   </data>
+  <data name="OrderPriorityLowSupportedValues" xml:space="preserve">
+    <value>Low</value>
+    <comment>Supported OrderPriority.Low values (separate by ','). Used in import.</comment>
+  </data>
+  <data name="OrderPriorityUrgentSupportedValues" xml:space="preserve">
+    <value>Urgent</value>
+    <comment>Supported OrderPriority.Urgent values (separate by ','). Used in import.</comment>
+  </data>
   <data name="OrderTypeDeliverySupportedValues" xml:space="preserve">
     <value>Delivery</value>
     <comment>Supported OrderType.Delivery values (separate by ','). Used in import.</comment>

--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/Resources/defaults.xml
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/Resources/defaults.xml
@@ -14,7 +14,7 @@
   </Locations>
   <Orders>
     <Type>Delivery</Type>
-    <Priority>Normal</Priority>
+    <Priority>Low</Priority>
     <CurbApproach>Both</CurbApproach>
     <ServiceTime>5</ServiceTime>
     <TimeWindow IsWideopen="true" />

--- a/RoutePlanner_DeveloperTools/Source/ArcLogistics/Routing/VrpRequestBuilder.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogistics/Routing/VrpRequestBuilder.cs
@@ -808,9 +808,8 @@ namespace ESRI.ArcLogistics.Routing
                 attrs.Add(NAAttribute.DELIVERY, null);
             }
 
-            // Revenue.
-            attrs.Add(NAAttribute.REVENUE,
-                unassignedOrder.Priority == OrderPriority.Normal ? 0 : (long)_orderRevenue);
+            // Revenue.            
+			attrs.Add(NAAttribute.REVENUE, (int)unassignedOrder.Priority);
 
             // Specialties.
             List<Guid> specIds = GetOrderSpecIds(unassignedOrder);

--- a/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Converters/OrderPriorityConverter.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Converters/OrderPriorityConverter.cs
@@ -48,11 +48,17 @@ namespace ESRI.ArcLogistics.App.Converters
                 switch (syncType)
                 {
                     // Convert selected synctype to it's string representation.
+					case OrderPriority.Urgent:                        
+                        result = App.Current.GetString("OrderPriorityUrgent");
+                        break;     
                     case OrderPriority.High:
                         result = App.Current.GetString("OrderPriorityHigh");
                         break;
                     case OrderPriority.Normal:
                         result = App.Current.GetString("OrderPriorityNormal");
+                        break;
+					case OrderPriority.Low:
+                        result = App.Current.GetString("OrderPriorityLow");
                         break;
                     default:
                         // Not supported Enum value.
@@ -78,10 +84,14 @@ namespace ESRI.ArcLogistics.App.Converters
             OrderPriority result;
 
             // Convert string to enum.
-            if (name == App.Current.GetString("OrderPriorityHigh"))
+            if (name == App.Current.GetString("OrderPriorityUrgent"))
+                result = OrderPriority.Urgent;
+            else if (name == App.Current.GetString("OrderPriorityHigh"))
                 result = OrderPriority.High;
             else if (name == App.Current.GetString("OrderPriorityNormal"))
                 result = OrderPriority.Normal;
+            else if (name == App.Current.GetString("OrderPriorityLow"))
+                result = OrderPriority.Low;
             else
             {
                 // Not supported Enum value.

--- a/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Mapping/TipGenerator.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Mapping/TipGenerator.cs
@@ -588,7 +588,7 @@ namespace ESRI.ArcLogistics.App.Mapping
         /// <param name="inlines">Inlines to fill</param>
         private static void _AddPriorityIfNeeded(Order order, InlineCollection inlines)
         {
-            if (order.Priority == OrderPriority.High)
+            if (order.Priority != OrderPriority.Low)
             {
                 string priority = order.Priority.ToString();
                 _AddLine(_priorityCaption, priority, inlines, false);

--- a/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Properties/Resources.Designer.cs
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Properties/Resources.Designer.cs
@@ -7821,6 +7821,15 @@ using System;
             }
         }
         
+		/// <summary>
+        ///   Looks up a localized string similar to Low.
+        /// </summary>
+        internal static string OrderPriorityLow {
+            get {
+                return ResourceManager.GetString("OrderPriorityLow", resourceCulture);
+            }
+        }        
+		
         /// <summary>
         ///   Looks up a localized string similar to Normal.
         /// </summary>
@@ -7830,6 +7839,15 @@ using System;
             }
         }
         
+		/// <summary>
+        ///   Looks up a localized string similar to Urgent.
+        /// </summary>
+        internal static string OrderPriorityUrgent {
+            get {
+                return ResourceManager.GetString("OrderPriorityUrgent", resourceCulture);
+            }
+        }
+                
         /// <summary>
         ///   Looks up a localized string similar to Order Properties:.
         /// </summary>

--- a/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Properties/Resources.resx
+++ b/RoutePlanner_DeveloperTools/Source/ArcLogisticsApp/Properties/Resources.resx
@@ -3450,6 +3450,12 @@ Microsoft Enterprise Library 4.1 - Microsoft Public License (Ms - PL)</value>
   <data name="OrderPriorityHigh" xml:space="preserve">
     <value>High</value>
   </data>
+  <data name="OrderPriorityLow" xml:space="preserve">
+    <value>Low</value>
+  </data>
+  <data name="OrderPriorityUrgent" xml:space="preserve">
+    <value>Urgent</value>
+  </data>
   <data name="QuickHelpWidgetCaption" xml:space="preserve">
     <value>Quick Help</value>
   </data>


### PR DESCRIPTION
Revenue (in VRP) maps to Priority (in Route Planner). Priority can now take any non negative integer value and the VRP will give more priority to higher values accordingly. We have created the following four priorities which can be customized further by developers extending this application:
Urgent = 1000000
High = 1000
Normal = 1
Low = 0